### PR TITLE
【Fix #22】解答用紙一覧画面を作成

### DIFF
--- a/app/controllers/answer_sheets_controller.rb
+++ b/app/controllers/answer_sheets_controller.rb
@@ -2,6 +2,10 @@ class AnswerSheetsController < ApplicationController
   before_action :authenticate_user!
   before_action :set_answer_sheet, only: %i(new create)
 
+  def index
+    @answer_sheets = current_user.answer_sheets.order(id: :desc)
+  end
+
   def new
     @answer_sheet = current_user.answer_sheets.build
     @answer = @answer_sheet.answers.build

--- a/app/views/answer_sheets/index.html.erb
+++ b/app/views/answer_sheets/index.html.erb
@@ -1,0 +1,35 @@
+<div class="jumbotron">
+  <h2>解答用紙一覧</h2>
+  <i class="far fa-copy fa-3x text-primary float-right"></i>
+  <br>
+</div>
+
+<% @answer_sheets.each do |as| %>
+  <div class="card my-4">
+    <div class="card-body">
+      <div class="small mb-3">
+        <div class="badge badge-primary px-2">
+          <%= as.exam.subject.name %>
+        </div>
+        <%= as.created_at %>
+      </div>
+
+      <p class="card-title"><strong><%= as.exam.title %></strong></p>
+
+      <div class="float-right">
+        <%= link_to as, class: "stretched-link" do %>
+          <i class="far fa-file-alt fa-lg fa-fw" title="Show"></i>
+        <% end %>
+
+        <span class="fa-stack">
+          <% if as.comments.present? %>
+            <i class="fas fa-comment-alt fa-lg text-primary" title="Comment"></i>
+          <% else %>
+            <i class="far fa-comment-alt fa-lg text-primary" title="Comment"></i>
+          <% end %>
+          <i class="fa text-primary"><%= as.comments.length %></i>
+        </span>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/exams/_form.html.erb
+++ b/app/views/exams/_form.html.erb
@@ -63,7 +63,7 @@
           <div class="form-row">
             <div class="form-group col">
               <p class="mb-2">Image(任意)</p>
-              <%= f.label :image, class: "btn btn-outline-secondary", style: "width:100%;" do %>
+              <%= f.label :image, class: "btn btn-outline-primary", style: "width:100%;" do %>
                 <i class="far fa-image"> 画像ファイルを選択</i>
               <% end %>
               <%= f.file_field :image, class: "image_form", style: "display:none;" %>

--- a/app/views/exams/index.html.erb
+++ b/app/views/exams/index.html.erb
@@ -1,18 +1,14 @@
 <div class="jumbotron">
-  <div class="container clearfix">
-    <h2 class="float-left">試験作成画面</h2>
-    <%= link_to new_exam_path, class: "btn btn-primary float-right" do %>
-      <i class="fas fa-pencil-alt"> New</i>
-    <% end %>
-  </div>
+  <h2>試験作成画面</h2>
+  <%= link_to new_exam_path, class: "btn btn-primary float-right" do %>
+    <i class="fas fa-pencil-alt"> New</i>
+  <% end %>
+  <br>
 </div>
 
 <% @exams.each do |exam| %>
-  <div class="card">
-
-    <div class="card-header">
-      <strong><%= exam.title %></strong> (<%= exam.subject.name %>)
-
+  <div class="card my-4">
+    <div class="card-body">
       <div class="float-right">
         <% if exam.release %>
           <div class="badge badge-pill badge-primary">公開</div>
@@ -20,23 +16,29 @@
           <div class="badge badge-pill badge-danger">非公開</div>
         <% end%>
       </div>
-    </div>
 
-    <div class="card-body">
+      <div class="small mb-3">
+        <div class="badge badge-primary px-2">
+          <%= exam.subject.name %>
+        </div>
+        <%= exam.created_at %>
+      </div>
+
+      <p class="card-title"><strong><%= exam.title %></strong></p>
 
       <div class="card-text">締切：<%= exam.deadline %></div>
 
       <div class="float-right">
         <%= link_to exam do %>
-          <i class="far fa-file-alt mx-1" title="Show"></i>
+          <i class="far fa-file-alt fa-lg fa-fw" title="Show"></i>
         <% end %>
 
         <%= link_to edit_exam_path(exam) do %>
-          <i class="far fa-edit mx-1" title="Edit"></i>
+          <i class="far fa-edit fa-lg fa-fw" title="Edit"></i>
         <% end %>
 
         <%= link_to exam, method: :delete, data: { confirm: 'Are you sure?' } do %>
-          <i class="far fa-trash-alt mx-1" title="Delete"></i>
+          <i class="far fa-trash-alt fa-lg fa-fw" title="Delete"></i>
         <% end %>
       </div>
     </div>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -7,6 +7,7 @@
     <p>がんばって取り組みましょう!</p>
     <i class="fas fa-pencil-alt fa-3x text-primary float-right"></i>
   <% end %>
+  <br>
 </div>
 
 <% @exams.each do |exam| %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -23,8 +23,13 @@
                 <%= link_to "マイページ", user_path, class: "nav-link" %>
               </li>
               <li class="nav-item">
-                <%= link_to "新規作成", exams_path, class: "nav-link" %>
+                <%= link_to "解答用紙", answer_sheets_path, class: "nav-link" %>
               </li>
+              <% if current_user.admin %>
+                <li class="nav-item">
+                  <%= link_to "問題管理ページ", exams_path, class: "nav-link" %>
+                </li>
+              <% end %>
             <% else %>
               <li class="nav-item">
                 <%= link_to "新規登録", new_user_registration_path, class: "nav-link" %>
@@ -73,7 +78,7 @@
               <% end %>
             </div>
             <div class="col">
-              <%= link_to user_path, class: "btn btn-outline-light", style: "width:100%;", title: "Answer Sheets" do %>
+              <%= link_to answer_sheets_path, class: "btn btn-outline-light", style: "width:100%;", title: "Answer Sheets" do %>
                 <i class="far fa-copy"></i>
               <% end %>
             </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
 
   resource :user, only: %i(show edit update)
 
-  resources :answer_sheets, only: %i(show result) do
+  resources :answer_sheets, only: %i(index show result) do
     get :result, on: :member
     resources :comments, only: %i(create edit update destroy)
   end


### PR DESCRIPTION
**解答用紙一覧画面**

- answer_sheetsのindexを作成
- home画面から飛ぶことができる(PC、スマホ両方)
- 並びは降順