### PR TITLE
【Fix #23】日本語辞書設定

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -7,7 +7,9 @@ class CommentsController < ApplicationController
       if @comment.save
         format.js { render :index }
       else
-        format.html { redirect_to answer_sheet_path(@answer_sheet), notice: "投稿できませんでした..." }
+        format.html { redirect_to answer_sheet_path(@answer_sheet),
+                      alert: t("views.messages.failed_to_comment")
+                    }
       end
     end
   end
@@ -15,7 +17,6 @@ class CommentsController < ApplicationController
   def edit
     @comment = current_user.comments.find(params[:id])
     respond_to do |format|
-      flash.now[:notice] = "コメントの編集中"
       format.js { render :edit }
     end
   end
@@ -24,11 +25,10 @@ class CommentsController < ApplicationController
     @comment = current_user.comments.find(params[:id])
       respond_to do |format|
         if @comment.update(comment_params)
-          flash.now[:notice] = "コメントが編集されました"
           format.js { render :index }
         else
-          flash.now[:notice] = "コメントの編集に失敗しました"
-          format.js { render :edit_error }
+          flash.now[:alert] = t("views.messages.failed_to_update_comment")
+          format.js { render :edit }
         end
       end
   end
@@ -37,7 +37,7 @@ class CommentsController < ApplicationController
     @comment = current_user.comments.find(params[:id])
     @comment.destroy
     respond_to do |format|
-      flash.now[:notice] = 'コメントが削除されました'
+      flash.now[:notice] = t("views.messages.delete_comment")
       format.js { render :index }
     end
   end

--- a/app/views/answer_sheets/index.html.erb
+++ b/app/views/answer_sheets/index.html.erb
@@ -11,7 +11,7 @@
         <div class="badge badge-primary px-2">
           <%= as.exam.subject.name %>
         </div>
-        <%= as.created_at %>
+        <%= l as.created_at, format: :long %>
       </div>
 
       <p class="card-title"><strong><%= as.exam.title %></strong></p>

--- a/app/views/answer_sheets/new.html.erb
+++ b/app/views/answer_sheets/new.html.erb
@@ -69,7 +69,7 @@
       <br>
 
       <div class="actions">
-        <%= form.submit class: "form-control btn btn-primary" %>
+        <%= form.submit class: "form-control btn btn-primary", data: { confirm: t("views.messages.are_you_sure") } %>
       </div>
     </div>
   </div>

--- a/app/views/answer_sheets/new.html.erb
+++ b/app/views/answer_sheets/new.html.erb
@@ -48,16 +48,16 @@
           <div class="btn-group btn-group-toggle" data-toggle="buttons">
             <%= form.fields_for :answers do |f| %>
 
-              <label class="btn btn-sm btn-outline-primary">
+              <label id="c1" class="btn btn-sm btn-outline-primary">
                 <%= f.radio_button :choice, 1, style: "display:none;", autocomplete: "off" %>1
               </label>
-              <label class="btn btn-sm btn-outline-primary">
+              <label id="c2" class="btn btn-sm btn-outline-primary">
                 <%= f.radio_button :choice, 2, style: "display:none;", autocomplete: "off" %>2
               </label>
-              <label class="btn btn-sm btn-outline-primary">
+              <label id="c3" class="btn btn-sm btn-outline-primary">
                 <%= f.radio_button :choice, 3, style: "display:none;", autocomplete: "off" %>3
               </label>
-              <label class="btn btn-sm btn-outline-primary rounded-right">
+              <label id="c4" class="btn btn-sm btn-outline-primary rounded-right">
                 <%= f.radio_button :choice, 4, style: "display:none;", autocomplete: "off" %>4
               </label>
               <%= f.hidden_field :question_id, value: question.id %>

--- a/app/views/answer_sheets/show.html.erb
+++ b/app/views/answer_sheets/show.html.erb
@@ -10,7 +10,7 @@
         <i class="fas fa-chart-area"> 詳細を見る</i>
       <% end %>
     </div>
-    解答日：<%= @answer_sheet.created_at %>
+    解答日：<%= l @answer_sheet.created_at, format: :long %>
   </div>
 </div>
 

--- a/app/views/comments/_edit.html.erb
+++ b/app/views/comments/_edit.html.erb
@@ -1,7 +1,6 @@
 <%= form_with(model: [answer_sheet, comment]) do |form| %>
   <% if comment.errors.any? %>
     <div id="error_explanation">
-      <h2><%= pluralize(comment.errors.count, "error") %> prohibited this comment from being saved:</h2>
       <ul>
       <% comment.errors.full_messages.each do |message| %>
         <li><%= message %></li>
@@ -17,7 +16,7 @@
       <%= form.submit class: "form-control btn btn-primary" %>
     </div>
     <div class="col">
-      <%= link_to "キャンセル", :back, class: "form-control btn btn-outline-primary" %>
+      <%= link_to t("views.link.back"), :back, class: "form-control btn btn-outline-primary" %>
     </div>
   </div>
 <% end %>

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -1,7 +1,6 @@
 <%= form_with(model: [answer_sheet, comment]) do |form| %>
   <% if comment.errors.any? %>
     <div id="error_explanation">
-      <h2><%= pluralize(comment.errors.count, "error") %> prohibited this comment from being saved:</h2>
       <ul>
       <% comment.errors.full_messages.each do |message| %>
         <li><%= message %></li>
@@ -17,7 +16,7 @@
       <%= form.submit class: "form-control btn btn-primary" %>
     </div>
     <div class="col">
-      <%= link_to "Back", :back, class: "form-control btn btn-outline-primary" %>
+      <%= link_to t("views.link.back"), answer_sheets_path, class: "form-control btn btn-outline-primary" %>
     </div>
   </div>
 <% end %>

--- a/app/views/comments/_index.html.erb
+++ b/app/views/comments/_index.html.erb
@@ -11,9 +11,9 @@
           <p><%= simple_format comment.content %></p>
           <p class="text-right">
             <% if current_user.id == comment.user_id || current_user.admin %>
-              <%= link_to "編集", edit_answer_sheet_comment_path(answer_sheet, comment), remote: true %>
-              <%= link_to "削除", answer_sheet_comment_path(comment.answer_sheet_id, comment.id), method: :delete, remote: true,
-                                          data: { confirm: "本当に削除しますか?"} %>
+              <%= link_to t("views.link.edit"), edit_answer_sheet_comment_path(answer_sheet, comment), remote: true %>
+              <%= link_to t("views.link.delete"), answer_sheet_comment_path(comment.answer_sheet_id, comment.id), method: :delete, remote: true,
+                                          data: { confirm: t("views.messages.are_you_sure") } %>
             <% end %>
           </p>
         </div>

--- a/app/views/comments/index.js.erb
+++ b/app/views/comments/index.js.erb
@@ -1,2 +1,3 @@
 $("#comments_area").html("<%= j(render 'comments/index', { comments: @comment.answer_sheet.comments, answer_sheet: @comment.answer_sheet }) %>")
 $("textarea").val('')
+$("#flash").html('<%= j(render partial: "layouts/flash") %>');

--- a/app/views/exams/_form.html.erb
+++ b/app/views/exams/_form.html.erb
@@ -1,8 +1,3 @@
-<div class="float-right">
-  <%= link_to "Back", :back %>
-</div>
-<br>
-
 <div class="card border-primary mx-auto p-4">
 
   <!-- Form (Exam info.) -->
@@ -62,7 +57,7 @@
 
           <div class="form-row">
             <div class="form-group col">
-              <p class="mb-2">Image(任意)</p>
+              <p class="mb-2">画像(任意)</p>
               <%= f.label :image, class: "btn btn-outline-primary", style: "width:100%;" do %>
                 <i class="far fa-image"> 画像ファイルを選択</i>
               <% end %>
@@ -88,8 +83,8 @@
     </div>
 
     <div class="form-row mt-4">
-      <%= form.submit "create", class: "form-control btn btn-primary col mx-1" %>
-      <%= link_to "Back", :back, class: "form-control btn btn-outline-primary col mx-1" %>
+      <%= form.submit class: "form-control btn btn-primary col mx-1" %>
+      <%= link_to t("views.link.back"), :back, class: "form-control btn btn-outline-primary col mx-1" %>
     </div>
   <% end %>
 </div>

--- a/app/views/exams/index.html.erb
+++ b/app/views/exams/index.html.erb
@@ -21,12 +21,12 @@
         <div class="badge badge-primary px-2">
           <%= exam.subject.name %>
         </div>
-        <%= exam.created_at %>
+        <%= l exam.created_at, format: :long %>
       </div>
 
       <p class="card-title"><strong><%= exam.title %></strong></p>
 
-      <div class="card-text">締切：<%= exam.deadline %></div>
+      <div class="card-text">締切：<%= l exam.deadline, format: :long %></div>
 
       <div class="float-right">
         <%= link_to exam do %>
@@ -37,7 +37,7 @@
           <i class="far fa-edit fa-lg fa-fw" title="Edit"></i>
         <% end %>
 
-        <%= link_to exam, method: :delete, data: { confirm: 'Are you sure?' } do %>
+        <%= link_to exam, method: :delete, data: { confirm: t("views.messages.are_you_sure") } do %>
           <i class="far fa-trash-alt fa-lg fa-fw" title="Delete"></i>
         <% end %>
       </div>

--- a/app/views/exams/show.html.erb
+++ b/app/views/exams/show.html.erb
@@ -1,6 +1,5 @@
 <div class="float-right">
-  <%= link_to "Edit", edit_exam_path(@exam) %>
-  <%= link_to "Back", exams_path %>
+  <%= link_to t("views.link.edit"), edit_exam_path(@exam) %>
 </div>
 <br>
 
@@ -8,7 +7,7 @@
 
   <div class="card-header">
     <div class="float-right">
-      作成日：<%= @exam.created_at.strftime("%Y/%m/%d") %>
+      作成日：<%= l @exam.created_at, format: :long %>
     </div>
     <h3><%= @exam.title %></h3>
   </div>
@@ -22,7 +21,7 @@
 
     <div>
       <p>締切：
-        <%= @exam.deadline %>
+        <%= l @exam.deadline %>
       </p>
     </div>
 

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -16,7 +16,7 @@
     <div class="row">
       <div class="col-4"><%= exam.title %></div>
       <div class="col-3"><%= exam.subject.name %></div>
-      <div class="col-3"><%= exam.deadline %></div>
+      <div class="col-3"><%= l exam.deadline, format: :short %></div>
       <% unless answer_check(exam) %>
         <div class="badge">
           <%= link_to new_exam_answer_sheet_path(exam) do %>

--- a/app/views/layouts/_flash.html.erb
+++ b/app/views/layouts/_flash.html.erb
@@ -1,0 +1,12 @@
+<div id="flash" class="text-light text-center">
+  <% if notice %>
+    <p class="bg-info">
+      <%= notice %>
+    </p>
+  <% end %>
+  <% if alert %>
+    <p class="bg-danger">
+      <%= alert %>
+    </p>
+  <% end %>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,7 +12,7 @@
 
   <!-- Header -->
   <body>
-    <header style="height:100px;">
+    <header style="height:80px;">
       <nav class="navbar navbar-expand-sm fixed-top navbar-dark bg-primary">
         <a class="navbar-brand" href="/" style="font-family:'Fredoka One',cursive; font-size:2.5rem;">Exam</a>
 
@@ -44,17 +44,8 @@
     </header>
 
     <!-- Notice or Alert -->
-    <div class="container" style="height:70px;">
-      <% if notice %>
-        <p class="alert alert-primary mx-auto" style="max-width:600px;">
-          <%= notice %>
-        </p>
-      <% end %>
-      <% if alert %>
-        <p class="alert alert-primary mx-auto" style="max-width:600px;">
-          <%= alert %>
-        </p>
-      <% end %>
+    <div style="height:60px;">
+      <%= render "layouts/flash" %>
     </div>
 
     <!-- Main -->

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -22,7 +22,7 @@
 <p>テスト成績</p>
 <% @user.answer_sheets.each do |as| %>
   <%= as.exam.title %>：
-  <%= link_to "詳細", answer_sheet_path(as) %>
+  <%= link_to t("views.link.show"), answer_sheet_path(as) %>
 <% end %>
 
 <%= area_chart [{ name: "得点", data: @point_charts }, { name: "平均点", data: @average_charts }] %>

--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -37,7 +37,7 @@ ja:
       send_instructions: アカウントの有効化について数分以内にメールでご連絡します。
       send_paranoid_instructions: メールアドレスが登録済みの場合、本人確認用のメールが数分以内に送信されます。
     failure:
-      already_authenticated: すでにログインしています。
+      already_authenticated: ""
       inactive: アカウントが有効化されていません。メールに記載された手順にしたがって、アカウントを有効化してください。
       invalid: "%{authentication_keys}またはパスワードが違います。"
       last_attempt: もう一回誤るとアカウントがロックされます。
@@ -114,8 +114,8 @@ ja:
       already_signed_out: 既にログアウト済みです。
       new:
         sign_in: ログイン
-      signed_in: ログインしました。
-      signed_out: ログアウトしました。
+      signed_in: ""
+      signed_out: ""
     shared:
       links:
         back: 戻る

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -7,6 +7,24 @@ ja:
         restrict_dependent_destroy:
           has_one: "%{record}が存在しているので削除できません"
           has_many: "%{record}が存在しているので削除できません"
+    attributes:
+      exam:
+        subject: 教科名
+        title: 試験名
+        deadline: 締切
+        release: 公開
+      question:
+        content: 問題文
+        correct_answer: 正解
+        description: 解説
+      answer_sheet:
+        score: 得点
+      answer:
+        choice: 選択
+    models:
+      exam: 試験
+      answer_sheet: 解答用紙
+      comment: コメント
   date:
     abbr_day_names:
     - 日
@@ -142,9 +160,9 @@ ja:
     select:
       prompt: 選択してください
     submit:
-      create: 登録する
-      submit: 保存する
-      update: 更新する
+      create: 送信
+      submit: 保存
+      update: 更新
   number:
     currency:
       format:
@@ -205,3 +223,14 @@ ja:
       long: "%Y/%m/%d %H:%M"
       short: "%m/%d %H:%M"
     pm: 午後
+  views:
+    link:
+      show: 詳細
+      edit: 編集
+      delete: 削除
+      back: 戻る
+    messages:
+      are_you_sure: 本当によろしいですか？
+      failed_to_comment: コメントできませんでした…
+      failed_to_update_comment: コメントを更新できませんでした…
+      delete_comment: コメントを削除しました

--- a/spec/system/answer_sheet_spec.rb
+++ b/spec/system/answer_sheet_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe '試験解答機能', type: :system do
         visit root_path
         sleep 0.5
         expect(page).to have_content 'ExamTitle'
-        expect(page).to have_content '2021-01-01'
+        expect(page).to have_content '01/01'
       end
 
       it '公開された試験情報なければ何も表示されない' do
@@ -31,7 +31,7 @@ RSpec.describe '試験解答機能', type: :system do
         visit root_path
         sleep 0.5
         expect(page).not_to have_content 'ExamTitle'
-        expect(page).not_to have_content '2021-01-01'
+        expect(page).not_to have_content '01/01'
         expect(page).to have_content '現在0件のテストがあります'
       end
 
@@ -41,7 +41,7 @@ RSpec.describe '試験解答機能', type: :system do
         visit root_path
         sleep 0.5
         expect(page).not_to have_content 'ExamTitle'
-        expect(page).not_to have_content '2021-01-01'
+        expect(page).not_to have_content '01/01'
         expect(page).to have_content '現在0件のテストがあります'
       end
     end
@@ -65,7 +65,6 @@ RSpec.describe '試験解答機能', type: :system do
         click_on '解答'
         sleep 0.5
         expect(page).to have_content 'ExamTitle'
-        expect(page).to have_content '2021-01-01'
         expect(page).to have_content 'QuestionText'
         expect(page).to have_selector('img[src$="test.jpg"]')
       end
@@ -75,7 +74,7 @@ RSpec.describe '試験解答機能', type: :system do
         sleep 0.5
         click_on '解答'
         sleep 0.5
-        expect(page).not_to have_content '解答：1'
+        expect(page).not_to have_content '解答:1'
       end
     end
 
@@ -83,32 +82,36 @@ RSpec.describe '試験解答機能', type: :system do
 
       it '結果ページに遷移する' do
         click_on '解答'
-        select '③', from: 'Choice'
-        click_on '登録する'
+        find('#c2').click
+        click_on '送信'
+        page.driver.browser.switch_to.alert.accept
         sleep 0.5
-        expect(page).to have_content '採点結果'
+        expect(page).to have_content '0／1点'
       end
 
       it '解答が正しければ1点と表示される' do
         click_on '解答'
-        select '①', from: 'Choice'
-        click_on '登録する'
+        find('#c1').click
+        click_on '送信'
+        page.driver.browser.switch_to.alert.accept
         sleep 0.5
-        expect(page).to have_content '1点'
+        expect(page).to have_content '1／1点'
       end
 
       it '解答が誤っていれば0点と表示される' do
         click_on '解答'
-        select '②', from: 'Choice'
-        click_on '登録する'
+        find('#c3').click
+        click_on '送信'
+        page.driver.browser.switch_to.alert.accept
         sleep 0.5
-        expect(page).to have_content '0点'
+        expect(page).to have_content '0／1点'
       end
 
       it '同じ問題を二度は解答できない' do
         click_on '解答'
-        select '②', from: 'Choice'
-        click_on '登録する'
+        find('#c4').click
+        click_on '送信'
+        page.driver.browser.switch_to.alert.accept
         sleep 0.5
         visit root_path
         expect(page).to have_content '解答済'

--- a/spec/system/comment_spec.rb
+++ b/spec/system/comment_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe 'コメント機能', type: :system do
         visit answer_sheet_path(id: 1)
         sleep 0.5
         fill_in 'コメントを入力', with: 'TestComment'
-        click_on '登録する'
+        click_on '送信'
       end
 
       it '自分のコメントがページに反映される' do
@@ -40,7 +40,7 @@ RSpec.describe 'コメント機能', type: :system do
         click_link '編集'
         sleep 0.5
         first('textarea').set('ExampleComment')
-        click_on '更新する'
+        click_on '更新'
         expect(page).to have_content 'ExampleComment'
       end
 
@@ -63,6 +63,5 @@ RSpec.describe 'コメント機能', type: :system do
         expect(page).not_to have_content '削除'
       end
     end
-
   end
 end

--- a/spec/system/exam_spec.rb
+++ b/spec/system/exam_spec.rb
@@ -20,8 +20,8 @@ RSpec.describe '試験作成機能', type: :system do
       it '作成済みの試験が表示され、子となる問題が1つ存在する' do
         visit exams_path
         expect(page).to have_content 'ExamTitle'
-        expect(page).to have_content '2021-01-01'
-        expect(page).to have_content '×'
+        expect(page).to have_content '2021年01月01日(金)'
+        expect(page).to have_content '非公開'
         expect( Question.count ).to eq 1
       end
     end
@@ -29,7 +29,7 @@ RSpec.describe '試験作成機能', type: :system do
     context '試験を削除した場合' do
       it '削除された試験は存在しなくなり、紐付けられた問題も削除される' do
         visit exams_path
-        click_on 'Destroy'
+        find('.fa-trash-alt').click
         page.driver.browser.switch_to.alert.accept
         sleep 0.5
         expect(page).not_to have_content 'ExamTitle'
@@ -50,30 +50,30 @@ RSpec.describe '試験作成機能', type: :system do
       before do
         visit exams_path
         click_on 'New'
-        fill_in 'Title', with: 'test_title'
+        fill_in '試験名', with: 'test_title'
         find('.subject').select('Japanese')
-        fill_in 'Deadline', with: '002020-12-31'
-        check 'Release'
-        attach_file 'Image', "#{Rails.root}/spec/factories/test.jpg", match: :first
-        fill_in 'Content', with: 'QuestionContent', match: :first
-        select '①', from: 'Correct answer', match: :first
-        click_on 'create'
+        fill_in '締切', with: '002020-12-31'
+        check '公開'
+        find('.image_form', visible: false, match: :first).set("#{Rails.root}/spec/factories/test.jpg")
+        fill_in '問題文', with: 'QuestionContent', match: :first
+        select '①', from: '正解', match: :first
+        click_on '送信'
       end
 
       it 'データが保存されている' do
         visit exams_path
         expect(page).to have_content 'test_title'
-        expect(page).to have_content '2020-12-31'
-        expect(page).to have_content '○'
+        expect(page).to have_content '2020年12月31日(木)'
+        expect(page).to have_content '公開'
       end
 
       it '詳細ページには問題情報も表示される' do
         visit exams_path
-        click_on 'Show'
+        find('.fa-file-alt').click
         sleep 0.5
         expect(page).to have_selector('img[src$="test.jpg"]')
         expect(page).to have_content 'QuestionContent'
-        expect(page).to have_content '1'
+        expect(page).to have_content '正解:1'
       end
     end
   end
@@ -90,15 +90,15 @@ RSpec.describe '試験作成機能', type: :system do
       it '該当の内容が表示されたページに遷移する' do
         exam = FactoryBot.create(:exam_with_question)
         visit exams_path
-        click_on 'Show'
+        find('.fa-file-alt').click
         sleep 0.5
         expect(page).to have_content 'ExamTitle'
         expect(page).to have_content 'Japanese'
-        expect(page).to have_content '2021-01-01'
+        expect(page).to have_content '2021/01/01'
         expect(page).to have_content '×'
         expect(page).to have_selector('img[src$="test.jpg"]')
         expect(page).to have_content 'QuestionText'
-        expect(page).to have_content '1'
+        expect(page).to have_content '正解:1'
       end
     end
   end
@@ -115,12 +115,13 @@ RSpec.describe '試験作成機能', type: :system do
       it '公開情報がtrueに変更される' do
         exam = FactoryBot.create(:exam_with_question)
         visit exams_path
-        click_on 'Edit'
+        find('.fa-edit').click
         sleep 0.5
-        check 'Release'
-        click_on 'create'
+        check '公開'
+        fill_in '締切', with: '002020-12-31'
+        click_on '更新'
         sleep 0.5
-        expect(page).to have_content '○'
+        expect(page).to have_content '公開'
       end
     end
   end

--- a/spec/system/user_spec.rb
+++ b/spec/system/user_spec.rb
@@ -28,39 +28,18 @@ RSpec.describe 'ユーザ管理機能', type: :system do
         expect(page).to have_content '山田花子'
         expect(page).to have_content 'yamada@example.com'
       end
-
-      it '試験ページに飛ぶことができる' do
-        visit root_path
-        click_link 'マイページ'
-        sleep 0.5
-        click_link '詳細'
-        sleep 0.5
-        expect(page).to have_content 'ExamTitle'
-        expect(page).to have_content '1点'
-      end
-
-      it '試験ページ詳細に飛ぶことができる' do
-        visit root_path
-        click_link 'マイページ'
-        sleep 0.5
-        click_link '詳細'
-        sleep 0.5
-        click_link '詳細をみる'
-        sleep 0.5
-        expect(page).to have_content '1点'
-        expect(page).to have_content '正解！！'
-        expect(page).to have_content 'あなたの選んだ答え：1'
-      end
     end
 
     context 'メールアドレスを編集した場合' do
       it '情報が更新される' do
         visit user_path
-        click_link '編集'
+        click_link 'プロフィールを編集'
         sleep 0.5
         fill_in 'Eメール', with: 'hanako@example.com'
-        click_on '更新する'
+        fill_in '現在のパスワード', with: 'password'
+        click_on '更新'
         sleep 0.5
+        click_link 'マイページ'
         expect(page).to have_content 'hanako@example.com'
       end
     end


### PR DESCRIPTION
**日本語辞書機能設定とシステムスペック**
#23 

- activerecord関連、リンク、メッセージ関連の辞書設定。
- それにともない、notice、alertの表示を変更。
- システムスペックを形式の変更に合わせて修正。