### PR TITLE
【Fix #46】編集権限バグ修正

### DIFF
--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -24,7 +24,8 @@ class Users::PasswordsController < Devise::PasswordsController
   # end
 
   def check_guest
-    if params[:user][:email].downcase == 'student@example.com' || 'teacher@example.com'
+    if params[:user][:email].downcase == 'student@example.com' ||
+       params[:user][:email].downcase == 'teacher@example.com'
       redirect_to new_user_session_path, alert: 'ゲストユーザーの変更・削除はできんのじゃ〜'
     end
   end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -40,7 +40,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
   # end
 
   def check_guest
-    if resource.student_id == 202001 || 777
+    if resource.student_id == 202001 || resource.student_id == 777
       redirect_to root_path, alert: 'ゲストユーザーの編集・削除はできんのじゃ〜'
     end
   end


### PR DESCRIPTION
ゲストログインユーザ以外もプロフィール編集ができなかったり、パスワード再設定ができなかったりするバグを修正。

ゲストユーザは変わらず編集権限は持てないようにしている。