### PR TITLE
【Fix #47】試験作成機能のバリデーション詳細を作成

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -10,6 +10,13 @@ $warning: #E91E63;
   font-family: 'M PLUS Rounded 1c', sans-serif;
 }
 
+.field_with_errors {
+  display: contents;
+  .form-control {
+    @extend .is-invalid;
+  }
+}
+
 @import "bootstrap";
 @import 'font-awesome-sprockets';
 @import 'font-awesome';

--- a/app/controllers/exams_controller.rb
+++ b/app/controllers/exams_controller.rb
@@ -17,7 +17,6 @@ class ExamsController < ApplicationController
       redirect_to exams_path
     else
       flash.now[:alert] = t("views.messages.failed_to_create")
-      5.times { @exam.questions.build }
       render :new
     end
   end

--- a/app/models/exam.rb
+++ b/app/models/exam.rb
@@ -21,7 +21,7 @@
 class Exam < ApplicationRecord
   belongs_to :subject
   has_many :questions, dependent: :destroy
-  accepts_nested_attributes_for :questions, reject_if: :all_blank, allow_destroy: true
+  accepts_nested_attributes_for :questions, allow_destroy: true
   has_many :answer_sheets
 
   validates :title, presence: true, length: { maximum: 255 }

--- a/app/views/exams/_form.html.erb
+++ b/app/views/exams/_form.html.erb
@@ -7,10 +7,21 @@
         <p style="font-size:0.8rem;"> ※ 公開にチェックを入れると試験情報が公開されます。</p>
       </h3>
 
+      <% if exam.errors.any? %>
+        <div id="error_explanation" class="text-warning">
+          <ul>
+          <% exam.errors.full_messages.each do |message| %>
+            <li><%= message %></li>
+          <% end %>
+          </ul>
+        </div>
+      <% end %>
+
+
       <div class="form-row">
         <div class="form-group col">
           <%= form.label :title %>
-          <%= form.text_field :title, class: "form-control" %>
+          <%= form.text_field :title, class: "form-control", required: true %>
         </div>
 
         <div class="form-group col-xs-2">
@@ -22,7 +33,7 @@
 
         <div class="form-group col">
           <%= form.label :deadline %>
-          <%= form.date_field :deadline, class: "form-control" %>
+          <%= form.date_field :deadline, class: "form-control", required: true %>
         </div>
 
         <!-- class="subject"はRSpec用の設定 -->
@@ -30,7 +41,8 @@
           <%= form.label :subject %>
           <%= form.collection_select(
             :subject_id, Subject.all, :id, :name,
-            { prompt: "選択してください" }, { class: "form-control" }
+            { prompt: "選択してください" }, class: "form-control",
+            required: true
           ) %>
         </div>
       </div>
@@ -49,7 +61,7 @@
 
           <div class="form-group">
             <%= f.label :content %>
-            <%= f.text_area :content, class: "form-control", size: "100x5" %>
+            <%= f.text_area :content, class: "form-control", size: "100x5", required: true %>
           </div>
 
           <div class="form-row">
@@ -66,7 +78,7 @@
               <%= f.select :correct_answer,
                 {'①':1, '②':2, '③':3, '④':4},
                 { include_blank: "選択してください" },
-                { class: "form-control" }
+                class: "form-control", required: true
               %>
             </div>
           </div>


### PR DESCRIPTION
**試験作成時に何が不足して送信できなかったのか修正**

バリデーションメッセージがつらつら出るのはあまり見栄え上美しくないので、基本的にはフォームヘルパーの`required:true`で示す実装を試みた。

あとは、CSSの設定でエラーの色をつけて視覚面の修正も加えた。
```
.field_with_errors {
  display: contents;
  .form-control {
    @extend .is-invalid;
  }
}
```