### PR TITLE
【Fix #48】試験作成のユーザビリティ向上

### DIFF
--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -13,6 +13,10 @@ class ImageUploader < CarrierWave::Uploader::Base
     "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
   end
 
+  def size_range
+    0..1.megabytes
+  end
+
   # Provide a default URL as a default if there hasn't been a file uploaded:
   # def default_url(*args)
   #   # For Rails 3.1+ asset pipeline compatibility:

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -26,7 +26,7 @@ class ImageUploader < CarrierWave::Uploader::Base
   # end
 
   # Process files as they are uploaded:
-  process resize_to_fill: [940, 705, "Center"]
+  # process resize_to_fill: [940, 705, "Center"]
   #
   # def scale(width, height)
   #   # do something

--- a/app/views/exams/_form.html.erb
+++ b/app/views/exams/_form.html.erb
@@ -58,6 +58,7 @@
 
         <div class="card border-primary p-2 my-3">
           <strong><%= "Q.#{n+=1}" %></strong>
+          <%= f.index + 1 %>
 
           <!-- Image Remove Btn -->
           <div id="remove_btn_<%= n %>"
@@ -68,6 +69,12 @@
           </div>
           <!-- Image Preview -->
           <img id="img_prev_<%= n %>" src="#" class="w-100" style="display:none;">
+
+          <% if exam.questions[n-1].image.present? %>
+            <p>
+              <%= image_tag exam.questions[n-1].image.url, id: "existing_img_#{n}", style: "width:100%;" %>
+            </p>
+          <% end %>
 
           <div class="form-group">
             <%= f.label :content %>
@@ -119,6 +126,8 @@
           .css('display', 'block');
         $(`#remove_btn_${n}`)
           .css('display', 'block');
+        $(`#existing_img_${n}`)
+          .css('display', 'none');
       };
 
       reader.readAsDataURL(input.files[0]);
@@ -132,5 +141,7 @@
       .css('display', 'none');
     $(`#remove_btn_${n}`)
       .css('display', 'none');
+    $(`#existing_img_${n}`)
+      .fadeIn(1500);
   };
 </script>

--- a/app/views/exams/_form.html.erb
+++ b/app/views/exams/_form.html.erb
@@ -58,7 +58,6 @@
 
         <div class="card border-primary p-2 my-3">
           <strong><%= "Q.#{n+=1}" %></strong>
-          <%= f.index + 1 %>
 
           <!-- Image Remove Btn -->
           <div id="remove_btn_<%= n %>"
@@ -83,7 +82,7 @@
 
           <div class="form-row">
             <div class="form-group col">
-              <p class="mb-2">画像(任意)</p>
+              <p class="mb-2">画像(任意)　<span class="small border-bottom border-dark">※1MB以下</span></p>
               <%= f.label :image, class: "btn btn-outline-primary", style: "width:100%;" do %>
                 <i class="far fa-image"> 画像ファイルを選択</i>
               <% end %>
@@ -119,6 +118,14 @@
   function readURL(input, n) {
     if (input.files && input.files[0]) {
       var reader = new FileReader();
+      var sizeInKB = input.files[0].size/1024;
+      var sizeLimit= 1000;
+
+      // file size validation
+      if (sizeInKB >= sizeLimit) {
+        alert("ファイルは1MB以下のサイズにしてください");
+        return false;
+      }
 
       reader.onload = function (e) {
         $(`#img_prev_${n}`)

--- a/app/views/exams/_form.html.erb
+++ b/app/views/exams/_form.html.erb
@@ -59,6 +59,16 @@
         <div class="card border-primary p-2 my-3">
           <strong><%= "Q.#{n+=1}" %></strong>
 
+          <!-- Image Remove Btn -->
+          <div id="remove_btn_<%= n %>"
+               class="text-warning"
+               style="display:none; cursor:pointer;"
+               onclick="remove_img(<%= n %>);">
+            <i class="far fa-window-close fa-2x"></i>
+          </div>
+          <!-- Image Preview -->
+          <img id="img_prev_<%= n %>" src="#" class="w-100" style="display:none;">
+
           <div class="form-group">
             <%= f.label :content %>
             <%= f.text_area :content, class: "form-control", size: "100x5", required: true %>
@@ -70,7 +80,7 @@
               <%= f.label :image, class: "btn btn-outline-primary", style: "width:100%;" do %>
                 <i class="far fa-image"> 画像ファイルを選択</i>
               <% end %>
-              <%= f.file_field :image, class: "image_form", style: "display:none;" %>
+              <%= f.file_field :image, class: "image_form_#{n}", style: "display:none;", onchange:"readURL(this, #{n});" %>
             </div>
 
             <div class="form-group col">
@@ -96,3 +106,31 @@
     </div>
   <% end %>
 </div>
+
+<!-- Jquery for Image Preview -->
+<script>
+  function readURL(input, n) {
+    if (input.files && input.files[0]) {
+      var reader = new FileReader();
+
+      reader.onload = function (e) {
+        $(`#img_prev_${n}`)
+          .attr('src', e.target.result)
+          .css('display', 'block');
+        $(`#remove_btn_${n}`)
+          .css('display', 'block');
+      };
+
+      reader.readAsDataURL(input.files[0]);
+    }
+  };
+
+  function remove_img(n) {
+    $(`.image_form_${n}`)
+      .val("");
+    $(`#img_prev_${n}`)
+      .css('display', 'none');
+    $(`#remove_btn_${n}`)
+      .css('display', 'none');
+  };
+</script>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -13,6 +13,8 @@ ja:
         title: 試験名
         deadline: 締切
         release: 公開
+      exam/questions:
+        image: 画像
       question:
         content: 問題文
         correct_answer: 正解
@@ -151,6 +153,7 @@ ja:
       too_long: は%{count}文字以内で入力してください
       too_short: は%{count}文字以上で入力してください
       wrong_length: は%{count}文字で入力してください
+      max_size_error: ファイルは1MB以下のサイズにしてください
     template:
       body: 次の項目を確認してください
       header:

--- a/spec/system/exam_spec.rb
+++ b/spec/system/exam_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe '試験作成機能', type: :system do
       click_button 'ログイン'
     end
 
-    context '項目をすべて入力(問題は1問)してcreateを押した場合' do
+    context '項目をすべて入力して作成した場合(画像は1問目のみとする)' do
       before do
         visit exams_path
         click_on 'New'
@@ -54,9 +54,12 @@ RSpec.describe '試験作成機能', type: :system do
         find('.subject').select('Japanese')
         fill_in '締切', with: '002020-12-31'
         check '公開'
-        find('.image_form', visible: false, match: :first).set("#{Rails.root}/spec/factories/test.jpg")
-        fill_in '問題文', with: 'QuestionContent', match: :first
-        select '①', from: '正解', match: :first
+        find('.image_form_1', visible: false, match: :first).set("#{Rails.root}/spec/factories/test.jpg")
+        for n in 0..4 do
+          all('textarea')[n].set("QuestionContent#{n}")
+          # selectの最初の要素が教科の選択なので、それを除くため"n+1"としている。
+          all('select')[n + 1].find("option[value='1']").select_option
+        end
         click_on '送信'
       end
 


### PR DESCRIPTION
#48 
>画像を登録しても、該当箇所に画像が登録済みかが判断できない。

試験作成時の画像プレビュー機能をJqueryで実装。
画像は×ボタンを押すことで消すこともできる。

また、試験編集時には、既存の画像が表示されるよう設定。
その際、画像を変更すると、同じように新しい画像がプレビューされ、×ボタンを押すと、既存の画像が再び表示されるようにした。

【追加実装】
アップローダ側のリサイズ設定を無効化し、あらたにアップロード時のサイズ制限を設定した。
サイズは上限1MB。これは、`1280×960の画像がおよそ0.7MB`であることから、このサイズあたりが実用性に鑑みて妥当であろうとの判断からである。