### PR TITLE
【Fix #54】学籍番号のバリデーション設定

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -36,7 +36,9 @@ class User < ApplicationRecord
   has_many :active_notifications, class_name: 'Notification', foreign_key: 'visitor_id', dependent: :destroy
   has_many :passive_notifications, class_name: 'Notification', foreign_key: 'visited_id', dependent: :destroy
 
-  validates :student_id, presence: true, uniqueness: true
+  validates :student_id,
+            presence: true, uniqueness: true,
+            numericality: { only_integer: true, greater_than: 0 }
   validates :name, presence: true, length: { maximum: 255 }
   validates :email, uniqueness: true, length: { maximum: 255 }
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -50,6 +50,17 @@ RSpec.describe User, type: :model do
     expect(user).to be_invalid
   end
 
+  it '学籍番号がマイナス入力の場合、無効である' do
+    user = User.new(
+      id: 1,
+      student_id: -1,
+      name: '田中太郎',
+      email: 'tanaka@example.com',
+      password: 'password',
+    )
+    expect(user).to be_invalid
+  end
+
   it '名前がない場合、無効である' do
     user = User.new(
       id: 1,


### PR DESCRIPTION
#54 
学籍番号がマイナス登録されないよう、バリデーションを設定。
モデルテストを追加し、テストパスを確認。