### PR TITLE
【Fix #55】画像リサイズを再設定

### DIFF
--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -26,7 +26,7 @@ class ImageUploader < CarrierWave::Uploader::Base
   # end
 
   # Process files as they are uploaded:
-  # process resize_to_fill: [940, 705, "Center"]
+  process resize_to_fit: [1000, 1000]
   #
   # def scale(width, height)
   #   # do something


### PR DESCRIPTION
#55 

画像アップロードでのリサイズを再設定した。
サイズは1000x1000で、PCでの最大サイズが横およそ1000pxであるので、そのサイズを基準にすることとした。
<img width="1235" alt="スクリーンショット 2020-08-14 11 50 35" src="https://user-images.githubusercontent.com/61282574/90208717-68ffb980-de24-11ea-8eff-fe559c1c60c8.png">
