### PR TITLE
【Fix #51】letter openerを本番環境用に設定

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,8 +33,10 @@ gem 'devise-i18n'
 gem 'rails_admin'
 gem 'cancancan'
 
-# faker data
+# Dev tool for Production
 gem 'faker'
+gem 'letter_opener_web'
+
 
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
@@ -53,7 +55,6 @@ group :development do
   gem 'listen', '>= 3.0.5', '< 3.2'
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
-  gem 'letter_opener_web'
 end
 
 group :test do

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -65,6 +65,9 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
+  config.action_mailer.default_url_options = { host: 'https://kk-exam.herokuapp.com'}
+  config.action_mailer.delivery_method = :letter_opener_web
+
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,7 +40,5 @@ Rails.application.routes.draw do
     end
   end
 
-  if Rails.env.development?
-    mount LetterOpenerWeb::Engine, at: "/letter_opener"
-  end
+  mount LetterOpenerWeb::Engine, at: "/letter_opener"
 end


### PR DESCRIPTION
#51 
現在Heroku用のSendgridが設定できないので、本番用のメイラーとしてもletter openerを設定することとした。