### PR TITLE
【Fix #59】メールアドレスのフォーマットバリデーションを設定

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -40,7 +40,8 @@ class User < ApplicationRecord
             presence: true, uniqueness: true,
             numericality: { only_integer: true, greater_than: 0 }
   validates :name, presence: true, length: { maximum: 255 }
-  validates :email, uniqueness: true, length: { maximum: 255 }
+  validates :email, uniqueness: true, length: { maximum: 255 },
+                    format: { with: /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i }
 
   default_scope -> { order(:id) }
 


### PR DESCRIPTION
#59 
ユーザ登録時のメールアドレスのフォーマットについてバリデーションを設定。

```
# user.rbにメールアドレスフォーマットを追加
validates :email, uniqueness: true, length: { maximum: 255 },
                  format: { with: /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i }
```