### PR TITLE
【Fix #65】試験分析機能を実装

### DIFF
--- a/app/controllers/analytics_controller.rb
+++ b/app/controllers/analytics_controller.rb
@@ -1,0 +1,12 @@
+class AnalyticsController < ApplicationController
+  before_action :authenticate_admin
+
+  def index
+    @questions = Question.select(:id, :exam_id, :content, :rate).order(:id)
+  end
+
+  def calculate
+    Question.calculate_correct_answer_rate
+    redirect_to analytics_path, notice: "正答率を更新しました"
+  end
+end

--- a/app/controllers/analytics_controller.rb
+++ b/app/controllers/analytics_controller.rb
@@ -2,7 +2,10 @@ class AnalyticsController < ApplicationController
   before_action :authenticate_admin
 
   def index
-    @questions = Question.select(:id, :exam_id, :content, :rate).order(:id)
+    @q = Question.select(:id, :exam_id, :content, :rate)
+                 .order(:id).ransack(params[:q])
+    @questions = @q.result.includes(:exam)
+
   end
 
   def calculate

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -7,7 +7,7 @@
 #  correct_answer :integer          not null
 #  description    :string
 #  image          :string
-#  rate           :integer
+#  rate           :decimal(, )
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
 #  exam_id        :bigint
@@ -28,4 +28,26 @@ class Question < ApplicationRecord
   validates :content, presence: true, length: { maximum: 65535 }
   validates :correct_answer, presence: true
   validates :description, length: { maximum: 255 }
+
+  # Method to calculate correct answer rate
+  def self.calculate_correct_answer_rate
+    @questions = self.all
+
+    @questions.each do |question|
+      if question.answers.length > 0
+        parameter = question.answers.length
+        num_of_correct_answers = 0
+
+        question.answers.each do |answer|
+          num_of_correct_answers += 1 if answer.choice == question.correct_answer
+        end
+
+        question.rate = num_of_correct_answers.to_f / parameter * 100
+        unless question.save
+          flash.now[:alert] = "正答率の更新に失敗しました"
+          render :index
+        end
+      end
+    end
+  end
 end

--- a/app/views/analytics/index.html.erb
+++ b/app/views/analytics/index.html.erb
@@ -7,12 +7,23 @@
   <br>
 </div>
 
-<table class="table table-sm table-bordered table-hover">
+<div>
+  <%= search_form_for(@q, url: analytics_path ) do |f| %>
+    <div class="input-group">
+      <%= f.search_field :exam_title_cont, class: "form-control offset-sm-6", placeholder: "キーワード検索" %>
+      <%= button_tag type: "submit", class: "input-group-append input-group-text" do %>
+        <i class="fas fa-search"></i>
+      <% end %>
+    </div>
+  <% end %>
+</div>
+
+<table class="table table-sm table-bordered table-hover my-4">
   <thead class="alert-primary">
     <tr>
-      <th scope="col">id</th>
-      <th scope="col">試験名</th>
-      <th scope="col">正答率</th>
+      <th scope="col"><%= sort_link(@q, :id) %></th>
+      <th scope="col"><%= sort_link(@q, :exam_title) %></th>
+      <th scope="col"><%= sort_link(@q, :rate) %></th>
       <th colspan="1"></th>
     </tr>
   </thead>

--- a/app/views/analytics/index.html.erb
+++ b/app/views/analytics/index.html.erb
@@ -1,0 +1,30 @@
+<div class="jumbotron">
+  <h2>試験分析画面(教員用)</h2>
+  <%= button_to calculate_analytics_path, method: :patch,
+                                  class: "btn btn-primary float-right" do %>
+    <i class="fas fa-chart-bar"> 正答率を算出</i>
+  <% end %>
+  <br>
+</div>
+
+<table class="table table-sm table-bordered table-hover">
+  <thead class="alert-primary">
+    <tr>
+      <th scope="col">id</th>
+      <th scope="col">試験名</th>
+      <th scope="col">正答率</th>
+      <th colspan="1"></th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @questions.each do |question| %>
+      <tr>
+        <th scope="row"><%= question.id %></th>
+        <td><%= question.exam.title %></td>
+        <td><%= question.rate ? "#{question.rate}%" : "算出なし" %></td>
+        <td><%= link_to t("views.link.show"), exam_path(question.exam) %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/analytics/index.html.erb
+++ b/app/views/analytics/index.html.erb
@@ -20,10 +20,10 @@
 
 <table class="table table-sm table-bordered table-hover my-4">
   <thead class="alert-primary">
-    <tr>
-      <th scope="col"><%= sort_link(@q, :id) %></th>
-      <th scope="col"><%= sort_link(@q, :exam_title) %></th>
-      <th scope="col"><%= sort_link(@q, :rate) %></th>
+    <tr class="text-center">
+      <th style="width:50px;"><%= sort_link(@q, :id) %></th>
+      <th style="width:40%;"><%= sort_link(@q, :exam_title) %></th>
+      <th><%= sort_link(@q, :rate) %></th>
       <th colspan="1"></th>
     </tr>
   </thead>
@@ -31,10 +31,10 @@
   <tbody>
     <% @questions.each do |question| %>
       <tr>
-        <th scope="row"><%= question.id %></th>
+        <th scope="row" class="text-center"><%= question.id %></th>
         <td><%= question.exam.title %></td>
         <td><%= question.rate ? "#{question.rate}%" : "算出なし" %></td>
-        <td><%= link_to t("views.link.show"), exam_path(question.exam) %></td>
+        <td class="text-center"><%= link_to t("views.link.show"), exam_path(question.exam) %></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/teacher/home/index.html.erb
+++ b/app/views/teacher/home/index.html.erb
@@ -24,8 +24,17 @@
   </div>
 
   <div class="card col-5 mx-auto my-2 p-4 border-primary">
+    <%= link_to analytics_path, class: "stretched-link" do %>
+      試験分析画面<i class="fas fa-chart-bar fa-2x float-right"></i>
+    <% end %>
+  </div>
+
+  <div class="card col-5 mx-auto my-2 p-4 border-primary">
     <%= link_to teacher_users_path, class: "stretched-link" do %>
       ユーザ管理画面<i class="fas fa-user fa-2x float-right"></i>
     <% end %>
+  </div>
+
+  <div class="card col-5 mx-auto my-2 p-4 border-white">
   </div>
 </div>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -19,6 +19,7 @@ ja:
         content: 問題文
         correct_answer: 正解
         description: 解説
+        rate: 正答率
       answer_sheet:
         score: 得点
       answer:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,5 +40,9 @@ Rails.application.routes.draw do
     end
   end
 
+  resources :analytics, only: %i(index calculate) do
+    patch :calculate, on: :collection
+  end
+
   mount LetterOpenerWeb::Engine, at: "/letter_opener"
 end

--- a/db/migrate/20200818064631_change_data_type_rate_of_questions.rb
+++ b/db/migrate/20200818064631_change_data_type_rate_of_questions.rb
@@ -1,0 +1,5 @@
+class ChangeDataTypeRateOfQuestions < ActiveRecord::Migration[5.2]
+  def change
+    change_column :questions, :rate, :numeric
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_04_014922) do
+ActiveRecord::Schema.define(version: 2020_08_18_064631) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -75,7 +75,7 @@ ActiveRecord::Schema.define(version: 2020_08_04_014922) do
     t.string "image"
     t.integer "correct_answer", null: false
     t.string "description"
-    t.integer "rate"
+    t.decimal "rate"
     t.bigint "exam_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/spec/factories/questions.rb
+++ b/spec/factories/questions.rb
@@ -7,7 +7,7 @@
 #  correct_answer :integer          not null
 #  description    :string
 #  image          :string
-#  rate           :integer
+#  rate           :decimal(, )
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
 #  exam_id        :bigint


### PR DESCRIPTION
#65 
**analyticsページを作成**
- 教員側からアクセス可能。
- 試験の各問題の正答率を算出し、一覧表示。

※正答率算出ロジックは以下の通り

`正答率を算出するクラスメソッドを作成`
`questionsテーブルのrateカラムを更新`
```
# question.rb

def self.calculate_correct_answer_rate
  @questions = self.all
  @questions.each do |question|
    if question.answers.length > 0
      parameter = question.answers.length
      num_of_correct_answers = 0

      question.answers.each do |answer|
        num_of_correct_answers += 1 if answer.choice == question.correct_answer
      end

      question.rate = num_of_correct_answers.to_f / parameter * 100
      unless question.save
        flash.now[:alert] = "正答率の更新に失敗しました"
        render :index
      end
    end
  end
end
```