### PR TITLE
【Fix #70】復習問題作成機能を実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,7 @@ gem 'chartkick'
 gem 'jquery-rails'
 gem 'bootstrap', '~> 4.5.0'
 gem 'font-awesome-sass', '~> 5.13.0'
+gem 'kaminari'
 
 # Backend
 gem 'jbuilder', '~> 2.5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -357,6 +357,7 @@ DEPENDENCIES
   font-awesome-sass (~> 5.13.0)
   jbuilder (~> 2.5)
   jquery-rails
+  kaminari
   launchy
   letter_opener_web
   listen (>= 3.0.5, < 3.2)

--- a/app/controllers/exams_controller.rb
+++ b/app/controllers/exams_controller.rb
@@ -14,7 +14,12 @@ class ExamsController < ApplicationController
 
   def renew
     @exam = Exam.new
-    @questions = Question.order(:id)
+    @questions = Question.order(:id).page(params[:page]).per(10)
+
+    respond_to do |format|
+      format.html
+      format.js
+    end
   end
 
   def create

--- a/app/controllers/exams_controller.rb
+++ b/app/controllers/exams_controller.rb
@@ -12,13 +12,26 @@ class ExamsController < ApplicationController
     5.times { @exam.questions.build }
   end
 
+  def renew
+    @exam = Exam.new
+    @questions = Question.order(:id)
+  end
+
   def create
     @exam = Exam.new(exam_params)
+    @path = Rails.application.routes.recognize_path(request.referer)
+
     if @exam.save
       redirect_to exams_path
     else
       flash.now[:alert] = t("views.messages.failed_to_create")
-      render :new
+
+      case @path[:action]
+      when "new"
+        render :new
+      when "renew"
+        render :renew
+      end
     end
   end
 
@@ -47,7 +60,7 @@ class ExamsController < ApplicationController
     @exam = Exam.find(params[:id])
   end
   def exam_params
-    params.require(:exam).permit(:title, :deadline, :release, :subject_id,
+    params.require(:exam).permit(:title, :deadline, :release, :subject_id, { question_ids: [] },
                                     questions_attributes:
                                     %i[id _destroy image content correct_answer description exam_id]
                                    )

--- a/app/controllers/exams_controller.rb
+++ b/app/controllers/exams_controller.rb
@@ -14,12 +14,6 @@ class ExamsController < ApplicationController
 
   def renew
     @exam = Exam.new
-    @questions = Question.order(:id).page(params[:page]).per(10)
-
-    respond_to do |format|
-      format.html
-      format.js
-    end
   end
 
   def create

--- a/app/views/exams/_renew_page.html.erb
+++ b/app/views/exams/_renew_page.html.erb
@@ -1,36 +1,54 @@
-<%= paginate @questions, remote: true %>
-<table class="table table-bordered table-hover">
-  <thead>
-    <tr class="text-center">
-      <th class="small">Id</th>
-      <th class="small">画像</th>
-      <th class="small">問題文</th>
-      <th class="small">正答率</th>
-      <th colspan="1"></th>
-    </tr>
-  </thead>
-  <tbody>
-    <%= collection_check_boxes(:exam, :question_ids, @questions, :id, :id) do |question| %>
-      <tr>
-        <td class="text-center"><%= question.object.id %></td>
-        <td class="text-center" style="min-width:50px;">
-          <% if question.object.image.present? %>
-            有
-          <% elsif %>
-            無
-          <% end %>
-        </td>
-        <td style="width:70%;"><%= simple_format question.object.content %></td>
-        <td><%= question.object.rate ? "#{question.object.rate}%" : "算出なし" %></td>
-        <td><%= question.check_box class: "q-check",
-                                   style: "-webkit-transform:scale(2,2);"
-            %>
-        </td>
-      </tr>
-    <% end %>
-  </tbody>
-</table>
-<%= paginate @questions, remote: true %>
+<div class="modal fade" id="exampleModalLong" tabindex="-1" role="dialog" aria-labelledby="exampleModalLongTitle" aria-hidden="true">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="exampleModalLongTitle">選択する問題にチェックしてください。</h5>
+        <button type="button" class="btn btn-sm btn-outline-primary" data-dismiss="modal">Close</button>
+      </div>
+      <div class="modal-body">
+        <button type="reset" class="btn btn-sm">
+          <i class="fas fa-trash text-dark"> 選択を全解除</i>
+        </button>
+        <table class="table table-bordered table-hover">
+          <thead>
+            <tr class="text-center">
+              <th class="small">Id</th>
+              <th class="small">画像</th>
+              <th class="small">問題文</th>
+              <th class="small">正答率</th>
+              <th colspan="1"></th>
+            </tr>
+          </thead>
+          <tbody>
+            <%= collection_check_boxes(:exam, :question_ids, Question.order(:id), :id, :id) do |question| %>
+              <tr>
+                <td class="text-center"><%= n = question.object.id %></td>
+                <td class="text-center" style="min-width:50px;">
+                  <% if question.object.image.present? %>
+                    有
+                  <% elsif %>
+                    無
+                  <% end %>
+                </td>
+                <td style="width:70%;"><%= simple_format question.object.content %></td>
+                <td><%= question.object.rate ? "#{question.object.rate}%" : "算出なし" %></td>
+                <td><%= question.check_box id: "checkbox_#{n}",
+                                           class: "q-check",
+                                           style: "-webkit-transform:scale(2,2);",
+                                           onchange: "checkListing(#{n});"
+                    %>
+                </td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-sm btn-outline-primary" data-dismiss="modal">Close</button>
+      </div>
+    </div>
+  </div>
+</div>
 
 <!-- Jquery for Checking the number of Questions -->
 <script>
@@ -46,4 +64,12 @@
       $('input[type=submit]').attr("disabled",true);
     }
   });
+  function checkListing(n) {
+    let list = `<li id="list_${n}" class="mx-4 list-inline-item"><span class="border border-primary rounded-pill px-3">${n}</span></li>`
+    if($(`#checkbox_${n}`).prop("checked") == true){
+      $("#check-list").append(list);
+    } else {
+      $(`#list_${n}`).remove();
+    };
+  };
 </script>

--- a/app/views/exams/_renew_page.html.erb
+++ b/app/views/exams/_renew_page.html.erb
@@ -1,0 +1,49 @@
+<%= paginate @questions, remote: true %>
+<table class="table table-bordered table-hover">
+  <thead>
+    <tr class="text-center">
+      <th class="small">Id</th>
+      <th class="small">画像</th>
+      <th class="small">問題文</th>
+      <th class="small">正答率</th>
+      <th colspan="1"></th>
+    </tr>
+  </thead>
+  <tbody>
+    <%= collection_check_boxes(:exam, :question_ids, @questions, :id, :id) do |question| %>
+      <tr>
+        <td class="text-center"><%= question.object.id %></td>
+        <td class="text-center" style="min-width:50px;">
+          <% if question.object.image.present? %>
+            有
+          <% elsif %>
+            無
+          <% end %>
+        </td>
+        <td style="width:70%;"><%= simple_format question.object.content %></td>
+        <td><%= question.object.rate ? "#{question.object.rate}%" : "算出なし" %></td>
+        <td><%= question.check_box class: "q-check",
+                                   style: "-webkit-transform:scale(2,2);"
+            %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+<%= paginate @questions, remote: true %>
+
+<!-- Jquery for Checking the number of Questions -->
+<script>
+  $("input[type=checkbox]").click(function(){
+    var count = $(".q-check:checked").length;
+    var not = $('.q-check').not(':checked')
+
+    if(count >= 5) {
+      not.attr("disabled",true);
+      $('input[type=submit]').attr("disabled",false);
+    } else {
+      not.attr("disabled",false);
+      $('input[type=submit]').attr("disabled",true);
+    }
+  });
+</script>

--- a/app/views/exams/index.html.erb
+++ b/app/views/exams/index.html.erb
@@ -1,8 +1,13 @@
 <div class="jumbotron">
   <h2>試験作成画面(教員用)</h2>
-  <%= link_to new_exam_path, class: "btn btn-primary float-right" do %>
-    <i class="fas fa-pencil-alt"> New</i>
-  <% end %>
+  <div class="float-right">
+    <%= link_to new_exam_path, class: "btn btn-primary m-1" do %>
+      <i class="fas fa-pencil-alt"> 新規作成</i>
+    <% end %>
+    <%= link_to renew_exams_path, class: "btn btn-primary m-1" do %>
+      <i class="fas fa-sync-alt"> 復習問題</i>
+    <% end %>
+  </div>
   <br>
 </div>
 

--- a/app/views/exams/renew.html.erb
+++ b/app/views/exams/renew.html.erb
@@ -54,37 +54,9 @@
       <h5 class="text-primary mb-4">問題選択欄
         <span class="ml-3 border-bottom border-primary">※ 5問選択してください。</span>
       </h5>
-      <table class="table table-bordered table-hover">
-        <thead>
-          <tr class="text-center">
-            <th class="small">Id</th>
-            <th class="small">画像</th>
-            <th class="small">問題文</th>
-            <th class="small">正答率</th>
-            <th colspan="1"></th>
-          </tr>
-        </thead>
-        <tbody>
-          <%= form.collection_check_boxes(:question_ids, @questions, :id, :id) do |question| %>
-            <tr>
-              <td class="text-center"><%= question.object.id %></td>
-              <td class="text-center" style="min-width:50px;">
-                <% if question.object.image.present? %>
-                  有
-                <% elsif %>
-                  無
-                <% end %>
-              </td>
-              <td style="width:70%;"><%= simple_format question.object.content %></td>
-              <td><%= question.object.rate ? "#{question.object.rate}%" : "算出なし" %></td>
-              <td><%= question.check_box class: "q-check",
-                                         style: "-webkit-transform:scale(2,2);"
-                  %>
-              </td>
-            </tr>
-          <% end %>
-        </tbody>
-      </table>
+      <div id="pagenate">
+        <%= render 'renew_page' %>
+      </div>
     </div>
 
     <div class="mt-4">
@@ -92,19 +64,3 @@
     </div>
   <% end %>
 </div>
-
-<!-- Jquery for Checking the number of Questions -->
-<script>
-  $("input[type=checkbox]").click(function(){
-    var count = $(".q-check:checked").length;
-    var not = $('.q-check').not(':checked')
-
-    if(count >= 5) {
-      not.attr("disabled",true);
-      $('input[type=submit]').attr("disabled",false);
-    } else {
-      not.attr("disabled",false);
-      $('input[type=submit]').attr("disabled",true);
-    }
-  });
-</script>

--- a/app/views/exams/renew.html.erb
+++ b/app/views/exams/renew.html.erb
@@ -50,12 +50,25 @@
 
     <hr class="border-primary">
 
+    <!-- Questions info. -->
     <div>
-      <h5 class="text-primary mb-4">問題選択欄
+      <div class="mb-4">
+
+        <!-- Button trigger modal -->
+        <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#exampleModalLong">
+          <i class="fas fa-mouse-pointer"> 問題選択</i>
+        </button>
         <span class="ml-3 border-bottom border-primary">※ 5問選択してください。</span>
-      </h5>
-      <div id="pagenate">
+      </div>
+
+      <!-- Modal -->
+      <div>
         <%= render 'renew_page' %>
+      </div>
+
+      <div class="card p-3" style="height:120px;">
+        <p>選択リスト(id)</p>
+        <ul id="check-list" class="list-inline mx-auto"></ul>
       </div>
     </div>
 

--- a/app/views/exams/renew.html.erb
+++ b/app/views/exams/renew.html.erb
@@ -1,0 +1,110 @@
+<div class="card border-primary mx-auto p-4">
+
+  <!-- Form (Exam info.) -->
+  <%= form_with(model: @exam, local: true) do |form| %>
+    <div>
+      <h3 class="text-primary">試験情報入力欄
+        <p style="font-size:0.8rem;"> ※ 公開にチェックを入れると試験情報が公開されます。</p>
+      </h3>
+
+      <% if @exam.errors.any? %>
+        <div id="error_explanation" class="text-warning">
+          <ul>
+          <% @exam.errors.full_messages.each do |message| %>
+            <li><%= message %></li>
+          <% end %>
+          </ul>
+        </div>
+      <% end %>
+
+
+      <div class="form-row">
+        <div class="form-group col">
+          <%= form.label :title %>
+          <%= form.text_field :title, class: "form-control", required: true %>
+        </div>
+
+        <div class="form-group col-xs-2">
+          <%= form.label :release %><br>
+          <%= form.check_box :release, class: "form-control" %>
+        </div>
+
+        <div class="w-100"></div>
+
+        <div class="form-group col">
+          <%= form.label :deadline %>
+          <%= form.date_field :deadline, class: "form-control", required: true %>
+        </div>
+
+        <!-- class="subject"はRSpec用の設定 -->
+        <div class="subject form-group col">
+          <%= form.label :subject %>
+          <%= form.collection_select(
+            :subject_id, Subject.all, :id, :name,
+            { prompt: "選択してください" }, class: "form-control",
+            required: true
+          ) %>
+        </div>
+      </div>
+    </div>
+
+    <hr class="border-primary">
+
+    <div>
+      <h5 class="text-primary mb-4">問題選択欄
+        <span class="ml-3 border-bottom border-primary">※ 5問選択してください。</span>
+      </h5>
+      <table class="table table-bordered table-hover">
+        <thead>
+          <tr class="text-center">
+            <th class="small">Id</th>
+            <th class="small">画像</th>
+            <th class="small">問題文</th>
+            <th class="small">正答率</th>
+            <th colspan="1"></th>
+          </tr>
+        </thead>
+        <tbody>
+          <%= form.collection_check_boxes(:question_ids, @questions, :id, :id) do |question| %>
+            <tr>
+              <td class="text-center"><%= question.object.id %></td>
+              <td class="text-center" style="min-width:50px;">
+                <% if question.object.image.present? %>
+                  有
+                <% elsif %>
+                  無
+                <% end %>
+              </td>
+              <td style="width:70%;"><%= simple_format question.object.content %></td>
+              <td><%= question.object.rate ? "#{question.object.rate}%" : "算出なし" %></td>
+              <td><%= question.check_box class: "q-check",
+                                         style: "-webkit-transform:scale(2,2);"
+                  %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+
+    <div class="mt-4">
+      <%= form.submit class: "form-control btn btn-primary col mx-1", disabled: true %>
+    </div>
+  <% end %>
+</div>
+
+<!-- Jquery for Checking the number of Questions -->
+<script>
+  $("input[type=checkbox]").click(function(){
+    var count = $(".q-check:checked").length;
+    var not = $('.q-check').not(':checked')
+
+    if(count >= 5) {
+      not.attr("disabled",true);
+      $('input[type=submit]').attr("disabled",false);
+    } else {
+      not.attr("disabled",false);
+      $('input[type=submit]').attr("disabled",true);
+    }
+  });
+</script>

--- a/app/views/exams/renew.js.erb
+++ b/app/views/exams/renew.js.erb
@@ -1,0 +1,1 @@
+$('#pagenate').html("<%= j(render 'renew_page') %>");

--- a/app/views/exams/renew.js.erb
+++ b/app/views/exams/renew.js.erb
@@ -1,1 +1,0 @@
-$('#pagenate').html("<%= j(render 'renew_page') %>");

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,6 +35,7 @@ Rails.application.routes.draw do
   resources :subjects, only: %i(index create edit update destroy)
 
   resources :exams do
+    get :renew, on: :collection
     resources :answer_sheets, only: %i(new create result) do
       get :result, on: :member
     end

--- a/spec/factories/exams.rb
+++ b/spec/factories/exams.rb
@@ -20,6 +20,14 @@
 #
 FactoryBot.define do
 
+  factory :exam do
+    id { 1 }
+    title { 'ExamTitle' }
+    subject_id { 1 }
+    deadline { '2021-01-01' }
+    release { false }
+  end
+
   factory :exam_with_question, class: Exam do
     id { 1 }
     title { 'ExamTitle' }

--- a/spec/system/exam_spec.rb
+++ b/spec/system/exam_spec.rb
@@ -128,4 +128,53 @@ RSpec.describe '試験作成機能', type: :system do
       end
     end
   end
+
+  describe '復習試験作成画面' do
+    before do
+      visit new_user_session_path
+      fill_in '学籍番号', with: 1
+      fill_in 'パスワード', with: 'password'
+      click_button 'ログイン'
+      FactoryBot.create(:exam)
+      for n in 1..5 do
+        FactoryBot.create(:question, id: n, content: "Content#{n}")
+      end
+    end
+
+    context '試験を作成した場合' do
+      before do
+        visit exams_path
+        click_on '復習問題'
+        fill_in '試験名', with: 'REtest_title'
+        find('.subject').select('Japanese')
+        fill_in '締切', with: '002020-12-31'
+        check '公開'
+        click_on '問題選択'
+        for n in 0..4 do
+          all('.q-check')[n].set(true)
+        end
+        click_on 'Close', match: :first
+        sleep 0.5
+        click_on '送信'
+      end
+
+      it 'データが保存されている' do
+        visit exams_path
+        expect(page).to have_content 'REtest_title'
+        expect(page).to have_content '2020年12月31日(木)'
+        expect(page).to have_content '公開'
+      end
+
+      it '詳細ページには問題が5問表示されている' do
+        visit exams_path
+        all('.fa-file-alt')[1].click
+        sleep 0.5
+        expect(page).to have_content 'Content1'
+        expect(page).to have_content 'Content2'
+        expect(page).to have_content 'Content3'
+        expect(page).to have_content 'Content4'
+        expect(page).to have_content 'Content5'
+      end
+    end
+  end
 end

--- a/spec/system/exam_spec.rb
+++ b/spec/system/exam_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe '試験作成機能', type: :system do
     context '項目をすべて入力して作成した場合(画像は1問目のみとする)' do
       before do
         visit exams_path
-        click_on 'New'
+        click_on '新規作成'
         fill_in '試験名', with: 'test_title'
         find('.subject').select('Japanese')
         fill_in '締切', with: '002020-12-31'


### PR DESCRIPTION
## 復習問題作成機能
#70 

**①exams_controllerに`renew`アクションを追加。**
このアクションで復習問題作成のページへ飛ぶ。
createアクションに関しては、従来のものに飛ばすよう設定。

**②問題に関してはQuestionモデル全体からチェックボックスで選ぶ**
問題のレコード数が増えるにつれて、読み込みの時間の問題や、ユーザビリティの低下の懸念がある。
そこで当初は以下の実装を試みた。
```
1. ページネーション
  gemのkaminariを導入。
  ただ本来のページネーションではページをめくるとリダイレクトする。
  そこでAjaxで非同期に。これにより、試験情報は消えないようになる。
```
### しかし、問題発生。

結局ページをめくることそのものはリダイレクトなので、チェックボックスをつけた項目は、`ページまたぎで保持されない`。

チェックの内容をセッション変数に入れて保持できるなどの情報もあるが、うまく実装できない。結局断念。別案を考えた。
```
2. モーダル
  選択項目のみが表示され、スクロールでストレスも少ない。
  レコード数が増えるにつれての問題は未だ残る。
```

実装としてはこれが妥協案。正直悔しい。