### PR TITLE
【Fix #74】試験分析画面の修正

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -17,6 +17,17 @@ $warning: #E91E63;
   }
 }
 
+.pagination>li>a {
+  border: none;
+  margin: 0 10px;
+}
+.pagination>.active>a {
+  border-radius: 15px;
+}
+.pagination>li>a:hover {
+  border-radius: 15px;
+}
+
 @import "bootstrap";
 @import 'font-awesome-sprockets';
 @import 'font-awesome';

--- a/app/controllers/analytics_controller.rb
+++ b/app/controllers/analytics_controller.rb
@@ -4,7 +4,7 @@ class AnalyticsController < ApplicationController
   def index
     @q = Question.select(:id, :exam_id, :content, :rate)
                  .order(:id).ransack(params[:q])
-    @questions = @q.result.includes(:exams, :exam_questions)
+    @questions = @q.result.includes(:exams).page(params[:page]).per(10)
 
   end
 

--- a/app/views/analytics/index.html.erb
+++ b/app/views/analytics/index.html.erb
@@ -22,7 +22,7 @@
   </div>
 </div>
 
-<table class="table table-sm table-bordered table-hover my-1">
+<table class="table table-sm table-bordered table-hover">
   <thead class="alert-primary">
     <tr class="text-center">
       <th style="width:50px;"><%= sort_link(@q, :id) %></th>
@@ -46,4 +46,7 @@
     <% end %>
   </tbody>
 </table>
-<%= paginate @questions %>
+
+<div class="my-3">
+  <%= paginate @questions %>
+</div>

--- a/app/views/analytics/index.html.erb
+++ b/app/views/analytics/index.html.erb
@@ -7,24 +7,27 @@
   <br>
 </div>
 
-<div>
-  <%= search_form_for(@q, url: analytics_path ) do |f| %>
-    <div class="input-group">
-      <%= f.search_field :exams_title_cont, class: "form-control offset-sm-6", placeholder: "キーワード検索" %>
-      <%= button_tag type: "submit", class: "input-group-append input-group-text" do %>
-        <i class="fas fa-search"></i>
-      <% end %>
-    </div>
-  <% end %>
+
+<div class="row">
+  <h3 class="text-primary col">問題分析</h3>
+  <div class="col">
+    <%= search_form_for(@q, url: analytics_path ) do |f| %>
+      <div class="input-group">
+        <%= f.search_field :exams_title_cont, class: "form-control", placeholder: "キーワード検索" %>
+        <%= button_tag type: "submit", class: "input-group-append input-group-text" do %>
+          <i class="fas fa-search"></i>
+        <% end %>
+      </div>
+    <% end %>
+  </div>
 </div>
 
-<table class="table table-sm table-bordered table-hover my-4">
+<table class="table table-sm table-bordered table-hover my-1">
   <thead class="alert-primary">
     <tr class="text-center">
       <th style="width:50px;"><%= sort_link(@q, :id) %></th>
-      <th style="width:40%;"><%= sort_link(@q, :exam_title) %></th>
-      <th><%= sort_link(@q, :rate) %></th>
-      <th colspan="1"></th>
+      <th style="width:25%;"><%= sort_link(@q, :rate) %></th>
+      <th><%= sort_link(@q, :exam_title, "採用されている試験名") %></th>
     </tr>
   </thead>
 
@@ -32,11 +35,15 @@
     <% @questions.each do |question| %>
       <tr>
         <th scope="row" class="text-center"><%= question.id %></th>
-        <!-- exams.firstとしているのは応急処置。今後仕様変更も検討。-->
-        <td><%= question.exams.first.title %></td>
         <td><%= question.rate ? "#{question.rate}%" : "算出なし" %></td>
-        <td class="text-center"><%= link_to t("views.link.show"), exam_path(question.exams) %></td>
+        <td>
+          <% question.exams.each_with_index do |exam, i| %>
+            <%= link_to exam.title, exam_path(exam) %>
+            <% if i != question.exams.length - 1 %>/<% end %>
+          <% end %>
+        </td>
       </tr>
     <% end %>
   </tbody>
 </table>
+<%= paginate @questions %>

--- a/app/views/kaminari/_first_page.html.erb
+++ b/app/views/kaminari/_first_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to raw(t 'views.pagination.first'), url, remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_gap.html.erb
+++ b/app/views/kaminari/_gap.html.erb
@@ -1,0 +1,3 @@
+<li class='page-item disabled'>
+  <%= link_to raw(t 'views.pagination.truncate'), '#', class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_last_page.html.erb
+++ b/app/views/kaminari/_last_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to raw(t 'views.pagination.last'), url, remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to raw(t 'views.pagination.next'), url, rel: 'next', remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -1,0 +1,9 @@
+<% if page.current? %>
+  <li class="page-item active">
+    <%= content_tag :a, page, data: { remote: remote }, rel: page.rel, class: 'page-link' %>
+  </li>
+<% else %>
+  <li class="page-item">
+    <%= link_to page, url, remote: remote, rel: page.rel, class: 'page-link' %>
+  </li>
+<% end %>

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -1,0 +1,17 @@
+<%= paginator.render do %>
+  <nav>
+    <ul class="pagination" style="justify-content: center;">
+      <%= first_page_tag %>
+      <%= prev_page_tag %>
+      <% each_page do |page| %>
+        <% if page.left_outer? || page.right_outer? || page.inside_window? %>
+          <%= page_tag page %>
+        <% elsif !page.was_truncated? -%>
+          <%= gap_tag %>
+        <% end %>
+      <% end %>
+      <%= next_page_tag %>
+      <%= last_page_tag %>
+    </ul>
+  </nav>
+<% end %>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to raw(t 'views.pagination.previous'), url, rel: 'prev', remote: remote, class: 'page-link' %>
+</li>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -238,3 +238,9 @@ ja:
       failed_to_create: 送信できませんでした…
       failed_to_update: 更新できませんでした…
       deleted: 削除しました
+    pagination:
+      first: <i class="fas fa-angle-double-left"></i>
+      last: <i class="fas fa-angle-double-right"></i>
+      previous: <i class="fas fa-angle-left"></i>
+      next: <i class="fas fa-angle-right"></i>
+      truncate: "..."


### PR DESCRIPTION
## 試験分析画面レイアウトを全体的に修正
#74 
このバグを受けて、このページを全面見直した。

<img width="711" alt="スクリーンショット 2020-08-27 0 49 13" src="https://user-images.githubusercontent.com/61282574/91327442-7ba0c800-e800-11ea-9631-e4051952593a.png">

### ①採用されている試験名項目を設定
- 試験：問題＝N：Nであるが、現設定ではその問題の最初の試験ページに飛ぶという無理やりな設定にしていたので、それを改善。関連づいた試験が複数あれば、それぞれにリンクで飛べるようにした。

### ②正答率を前に持ってきた
- まずはその問題の正答率が最初にあったほうがよいと判断。問題の情報が先にあって、その後に関連の試験情報があるというのが自然な流れと考えたため。

### ③ページネーション設定
- 問題数が増えるごとに情報量は増えるので、ページで見栄え感を向上。
