### PR TITLE
【Fix #72】試験削除の条件設定を修正

### DIFF
--- a/app/controllers/exams_controller.rb
+++ b/app/controllers/exams_controller.rb
@@ -49,8 +49,11 @@ class ExamsController < ApplicationController
   end
 
   def destroy
-    @exam.destroy
-    redirect_to exams_path, notice: t("views.messages.deleted")
+    if @exam.destroy
+      redirect_to exams_path, notice: t("views.messages.deleted")
+    else
+      redirect_to exams_path, alert: t("views.messages.cant_delete_if_exam_has_answer_sheets")
+    end
   end
 
   private

--- a/app/models/exam.rb
+++ b/app/models/exam.rb
@@ -20,10 +20,10 @@
 #
 class Exam < ApplicationRecord
   belongs_to :subject
+  has_many :answer_sheets, dependent: :restrict_with_error
   has_many :exam_questions, dependent: :destroy
   has_many :questions, through: :exam_questions
   accepts_nested_attributes_for :questions, allow_destroy: true
-  has_many :answer_sheets
 
   validates :title, presence: true, length: { maximum: 255 }
   validate :date_not_before_today

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -238,6 +238,7 @@ ja:
       failed_to_create: 送信できませんでした…
       failed_to_update: 更新できませんでした…
       deleted: 削除しました
+      cant_delete_if_exam_has_answer_sheets: すでに解答されている試験は削除できません
     pagination:
       first: <i class="fas fa-angle-double-left"></i>
       last: <i class="fas fa-angle-double-right"></i>

--- a/spec/system/exam_spec.rb
+++ b/spec/system/exam_spec.rb
@@ -25,17 +25,6 @@ RSpec.describe '試験作成機能', type: :system do
         expect( Question.count ).to eq 1
       end
     end
-
-    context '試験を削除した場合' do
-      it '削除された試験は存在しなくなり、紐付けられた問題も削除される' do
-        visit exams_path
-        find('.fa-trash-alt').click
-        page.driver.browser.switch_to.alert.accept
-        sleep 0.5
-        expect(page).not_to have_content 'ExamTitle'
-        expect( Question.count ).to eq 0
-      end
-    end
   end
 
   describe '試験作成画面' do
@@ -125,6 +114,44 @@ RSpec.describe '試験作成機能', type: :system do
         click_on '更新'
         sleep 0.5
         expect(page).to have_content '公開'
+      end
+    end
+  end
+
+  describe '試験削除画面' do
+    before do
+      visit new_user_session_path
+      fill_in '学籍番号', with: 1
+      fill_in 'パスワード', with: 'password'
+      click_button 'ログイン'
+      exam = FactoryBot.create(:exam_with_question)
+    end
+
+    context 'まだ解答されていない試験だった場合' do
+      it '削除された試験は存在しなくなり、紐付けられた問題も削除される' do
+        visit exams_path
+        find('.fa-trash-alt').click
+        page.driver.browser.switch_to.alert.accept
+        sleep 0.5
+        expect(page).not_to have_content 'ExamTitle'
+        expect( Question.count ).to eq 0
+      end
+    end
+
+    context 'すでに解答されている試験だった場合' do
+      before do
+        FactoryBot.create(:user)
+        FactoryBot.create(:answer_sheet_with_answer)
+      end
+
+      it '試験は削除できない' do
+        visit exams_path
+        find('.fa-trash-alt').click
+        page.driver.browser.switch_to.alert.accept
+        sleep 0.5
+        expect(page).to have_content 'ExamTitle'
+        expect( Question.count ).to eq 1
+        expect(page).to have_content 'すでに解答されている試験は削除できません'
       end
     end
   end


### PR DESCRIPTION
## 試験の削除に関するバグを受けて
#72 

試験削除についての設定は、そもそも甘いものであった。
モデルへの設定として、`試験が削除されれば、問題も一緒に削除される`ようにしている。
```
dependent: :destroy
```
しかし、[exams]--<[answer_sheets]の関連付けがあるため、すでに作成された解答用紙が一緒に消えるとそれはまずいので、こちら側には`dependent: :destroy`をつけていない。

### ゆえに、
**すでに解答されている試験は外部キー制約によってそもそも削除できない。**

### そこで、モデルの関連付け設定を変更
```
# exam.rb

# 子となる解答用紙が存在していれば削除できないよう設定
has_many :answer_sheets, dependent: :restrict_with_error
```

```
# exams_controller.rb

# destroyアクションの条件分岐を設定
def destroy
  if @exam.destroy
    redirect_to exams_path, notice: t("views.messages.deleted")
  else
    redirect_to exams_path, alert: t("views.messages.cant_delete_if_exam_has_answer_sheets")
  end
end
```

### エラーメッセージを出すようにした。
<img width="838" alt="スクリーンショット 2020-08-27 16 30 18" src="https://user-images.githubusercontent.com/61282574/91410950-a3387480-e882-11ea-8a7f-f6e77fe016e4.png">
