### PR TITLE
【Fix #77】試験分析画面の問題内容を表示

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -28,6 +28,21 @@ $warning: #E91E63;
   border-radius: 15px;
 }
 
+.tooltip {
+  opacity: 1 !important;
+}
+.tooltip > .tooltip-inner {
+  text-align: left;
+  padding: 20px;
+  background-color: $primary;
+}
+.tooltip-auto[x-placement^=bottom] .arrow::before,
+.tooltip .arrow::before {
+  bottom: 0;
+  border-width: 0 !important;
+  border-bottom-color: #fff !important;
+}
+
 @import "bootstrap";
 @import 'font-awesome-sprockets';
 @import 'font-awesome';

--- a/app/views/analytics/index.html.erb
+++ b/app/views/analytics/index.html.erb
@@ -23,6 +23,7 @@
 </div>
 
 <table class="table table-sm table-bordered table-hover">
+  <caption><i class="fas fa-search-plus fa-fw"></i> idにカーソルをあてると、問題文が表示されます。</caption>
   <thead class="alert-primary">
     <tr class="text-center">
       <th style="width:50px;"><%= sort_link(@q, :id) %></th>
@@ -34,7 +35,10 @@
   <tbody>
     <% @questions.each do |question| %>
       <tr>
-        <th scope="row" class="text-center"><%= question.id %></th>
+        <th scope="row" class="text-center" data-toggle="tooltip" data-html="true"
+            data-delay='{ "show": 200 }' data-placement="right" title="<%= simple_format question.content %>">
+          <%= question.id %>
+        </th>
         <td><%= question.rate ? "#{question.rate}%" : "算出なし" %></td>
         <td>
           <% question.exams.each_with_index do |exam, i| %>
@@ -50,3 +54,9 @@
 <div class="my-3">
   <%= paginate @questions %>
 </div>
+
+<script>
+  $(function () {
+    $('[data-toggle="tooltip"]').tooltip();
+  })
+</script>


### PR DESCRIPTION
## 試験分析画面における問題文のTooltips表示を設定
#77 
> 問題idのみでは、どんな問題なのか分からない。

### ということで

## Tooltipsで表示してみた。
<img width="715" alt="スクリーンショット 2020-08-28 22 59 45" src="https://user-images.githubusercontent.com/61282574/91574691-2db3cd80-e982-11ea-9197-b49001a31c83.png">

わかるように下に説明を追加。
ちなみにツールチップスはCSSで装飾を施している。
内容は以下の通り。
```
# application.scss

.tooltip {
  opacity: 1 !important;
}
.tooltip > .tooltip-inner {
  text-align: left;
  padding: 20px;
  background-color: $primary;
}
.tooltip-auto[x-placement^=bottom] .arrow::before,
.tooltip .arrow::before {
  bottom: 0;
  border-width: 0 !important;
  border-bottom-color: #fff !important;
}
```
