### PR TITLE
【Fix #79】試験管理画面の並びを変更

### DIFF
--- a/app/controllers/exams_controller.rb
+++ b/app/controllers/exams_controller.rb
@@ -3,7 +3,7 @@ class ExamsController < ApplicationController
   before_action :set_exam, only: %i(show edit update destroy)
 
   def index
-    @q = Exam.ransack(params[:q])
+    @q = Exam.order(id: :desc).ransack(params[:q])
     @exams = @q.result(distinct: true)
   end
 


### PR DESCRIPTION
## 試験管理画面の試験一覧を降順に

exams_controller.rb
<img width="395" alt="スクリーンショット 2020-08-31 11 19 40" src="https://user-images.githubusercontent.com/61282574/91676768-df6a1e80-eb7b-11ea-9307-39f825db30c7.png">
※`order(id: :desc)`を追加

試験が増えていく中で新しい試験情報が上に来ていることが望ましいと考えて、降順に設定をしてみた。